### PR TITLE
Fix to allow cmacro run in ccl

### DIFF
--- a/src/cmacro.lisp
+++ b/src/cmacro.lisp
@@ -9,7 +9,7 @@
 (in-package :cmacro)
 
 (defun quit ()
-  (sb-ext:exit :code -1))
+  (uiop:quit -1))
 
 (setf *debugger-hook* #'(lambda (c h)
                           (declare (ignore h))


### PR DESCRIPTION
This PR allows cmacro to run in Clozure Common Lisp.
Have tested in macOS 10.13.5 Clozure Common Lisp 1.11.6.