### PR TITLE
Fix non-C operator parsing

### DIFF
--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -167,7 +167,7 @@
 
 (defrule group-separator (group-separatorp character))
 
-(defrule op-char (not (or alphanumeric group-separator whitespace)))
+(defrule op-char (not (or alphanumeric group-separator whitespace #\$ #\@)))
 
 (defrule operator (+ op-char)
   (:lambda (list &bounds start-pos)


### PR DESCRIPTION
$ and @ should not be treated as C operators since they belong to
cmacro.

Fixes #11