### PR TITLE
Fix missing --no-expand impl

### DIFF
--- a/src/macroexpand.lisp
+++ b/src/macroexpand.lisp
@@ -92,3 +92,6 @@
 
 (defun macroexpand-pathname (pathname)
   (macroexpand-result (extract-macros (parse-pathname pathname))))
+
+(defun macronoexpand-pathname (pathname)
+  (result-ast (extract-macros (parse-pathname pathname))))


### PR DESCRIPTION
`-h` specifies `--no-expand` but there's no implementation for it.